### PR TITLE
Added The Ability to Load Drones Outside the Gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 *~
+.idea

--- a/lib/app_drone.rb
+++ b/lib/app_drone.rb
@@ -6,11 +6,13 @@ require 'active_support/inflector'
 lib_files = %w(version dependency_chain template drone object_extensions)
 lib_files.each { |f| require "app_drone/#{f}" }
 
-# require all drones in app_drone/drones, exclude 'zzz' folder
-drone_paths = Pathname.new(File.dirname(__FILE__) + '/app_drone/drones')
-drones = drone_paths.children.select(&:directory?).map { |path| path.split.last.to_s }
-drones -= ['zzz']
-drones.each { |d| require "app_drone/drones/#{d}/#{d}" }
-
 module AppDrone
+  def self.require_drones_at_path(drone_paths)
+    drone_paths = Pathname.new(drone_paths)
+    drones = drone_paths.children.select(&:directory?).map { |path| path.split.last.to_s }
+    drones -= ['zzz']
+    drones.each { |d| require  "#{drone_paths.to_path}/#{d}/#{d}" }
+  end
 end
+
+AppDrone.require_drones_at_path "#{File.dirname(__FILE__)}/app_drone/drones"


### PR DESCRIPTION
I've added the ability to load drones that do not exist in the drone app without modifying the default behavior.  This will allow users to use their own drones without having to modify the core drone gem.
